### PR TITLE
Detect tail call support of browser

### DIFF
--- a/lib-backend-wasm/src/lib.rs
+++ b/lib-backend-wasm/src/lib.rs
@@ -90,6 +90,15 @@ pub struct Options {
     wasm_bulk_memory: bool, // Whether we can generate code that uses the WebAssembly bulk memory proposal
     wasm_tail_call: bool, // Whether we can generate code that uses the WebAssembly tail call proposal
 }
+impl Options {
+    pub fn new(wasm_multi_value: bool, wasm_bulk_memory: bool, wasm_tail_call: bool) -> Options {
+        Options {
+            wasm_multi_value,
+            wasm_bulk_memory,
+            wasm_tail_call,
+        }
+    }
+}
 
 /**
  * This is the main function that invokes everything in the backend.

--- a/lib-backend-wasm/src/lib.rs
+++ b/lib-backend-wasm/src/lib.rs
@@ -90,6 +90,7 @@ pub struct Options {
     wasm_bulk_memory: bool, // Whether we can generate code that uses the WebAssembly bulk memory proposal
     wasm_tail_call: bool, // Whether we can generate code that uses the WebAssembly tail call proposal
 }
+
 impl Options {
     pub fn new(wasm_multi_value: bool, wasm_bulk_memory: bool, wasm_tail_call: bool) -> Options {
         Options {

--- a/source-compiler/src/lib.rs
+++ b/source-compiler/src/lib.rs
@@ -76,7 +76,11 @@ impl projstd::log::Logger for MainLogger {
  * `import_spec`: list of imports following the import file format
  */
 #[wasm_bindgen]
-pub async fn compile(context: i32, source_code: String) -> js_sys::Uint8Array {
+pub async fn compile(
+    context: i32,
+    source_code: String,
+    enable_tail_calls: bool,
+) -> js_sys::Uint8Array {
     // nice console errors in debug mode
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
@@ -92,8 +96,10 @@ pub async fn compile(context: i32, source_code: String) -> js_sys::Uint8Array {
         )
         .await?;
         let ir_program_opt = ir::opt::optimize_all(ir_program);
-        let wasm_module =
-            backend_wasm::run_backend(&ir_program_opt, backend_wasm::Options::default());
+        let wasm_module = backend_wasm::run_backend(
+            &ir_program_opt,
+            backend_wasm::Options::new(false, false, enable_tail_calls),
+        );
         let mut receiver = std::vec::Vec::<u8>::new();
         wasm_module.wasm_serialize(&mut receiver);
         Ok(js_sys::Uint8Array::from(receiver.as_slice()))

--- a/source-compiler/src/lib.rs
+++ b/source-compiler/src/lib.rs
@@ -79,7 +79,9 @@ impl projstd::log::Logger for MainLogger {
 pub async fn compile(
     context: i32,
     source_code: String,
-    enable_tail_calls: bool,
+    enable_multi_value: bool,
+    enable_bulk_memory: bool,
+    enable_tail_call: bool,
 ) -> js_sys::Uint8Array {
     // nice console errors in debug mode
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
@@ -98,7 +100,7 @@ pub async fn compile(
         let ir_program_opt = ir::opt::optimize_all(ir_program);
         let wasm_module = backend_wasm::run_backend(
             &ir_program_opt,
-            backend_wasm::Options::new(false, false, enable_tail_calls),
+            backend_wasm::Options::new(enable_multi_value, enable_bulk_memory, enable_tail_call),
         );
         let mut receiver = std::vec::Vec::<u8>::new();
         wasm_module.wasm_serialize(&mut receiver);

--- a/sourceror-driver/package.json
+++ b/sourceror-driver/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "acorn": "^7.3.1",
     "js-slang": "^0.4.60",
-    "node-getopt": "^0.3.2"
+    "node-getopt": "^0.3.2",
+    "wasm-feature-detect": "^1.2.9"
   },
   "devDependencies": {
     "@types/estree": "^0.0.45",

--- a/sourceror-driver/src/index.ts
+++ b/sourceror-driver/src/index.ts
@@ -8,7 +8,7 @@ export { makePlatformImports } from "./platform";
 import { Transcoder } from "./transcoder";
 export { Transcoder };
 import { cachedGetFile } from "./cache";
-import { tailCall } from "wasm-feature-detect";
+import { bulkMemory, multiValue, tailCall } from "wasm-feature-detect";
 
 export class CompileError extends Error {
 	constructor(message: string) {
@@ -135,10 +135,17 @@ export async function compile(
 		}
 	);
 
-	let isTailCallSupported = await tailCall();
-	console.info("WASM Tail Calls supported: ", isTailCallSupported);
+	
 
-	return Sourceror.compile(wasm_context, es_str, isTailCallSupported)
+	const compilationFlags: Sourceror.CompilationFlags = {
+		tailCall: await tailCall(),
+		bulkMemory: await bulkMemory(),
+		multiValue: await multiValue()
+	};
+	
+	console.info("WASM compilation falags: ", compilationFlags);
+
+	return Sourceror.compile(wasm_context, es_str, compilationFlags)
 		.then((wasm_binary: Uint8Array) => {
 			if (wasm_binary.byteLength > 0) {
 				return WebAssembly.compile(wasm_binary).catch((err: string) => {

--- a/sourceror-driver/src/index.ts
+++ b/sourceror-driver/src/index.ts
@@ -11,325 +11,357 @@ import { cachedGetFile } from "./cache";
 import { tailCall } from "wasm-feature-detect";
 
 export class CompileError extends Error {
-  constructor(message: string) {
-    super(message);
-  }
+	constructor(message: string) {
+		super(message);
+	}
 }
 
 export class RuntimeError extends Error {
-  constructor(message: string) {
-    super(message);
-  }
+	constructor(message: string) {
+		super(message);
+	}
 }
 
 class SyntacticParser extends AcornParser {
-  raiseRecoverable(pos: any, message: string) {
-    if (message.includes("Identifier ") && message.includes(" has already been declared")) return;
-    (AcornParser.prototype as any).raiseRecoverable.call(this, pos, message);
-  }
+	raiseRecoverable(pos: any, message: string) {
+		if (
+			message.includes("Identifier ") &&
+			message.includes(" has already been declared")
+		)
+			return;
+		(AcornParser.prototype as any).raiseRecoverable.call(this, pos, message);
+	}
 }
 
 function createImportOptions(err_handler: () => void): AcornOptions {
-  return {
-    sourceType: 'module',
-    ecmaVersion: 6,
-    locations: true,
-    // tslint:disable-next-line:no-any
-    onInsertedSemicolon(end: any, loc: any) {
-      err_handler();
-    },
-    // tslint:disable-next-line:no-any
-    onTrailingComma(_end: any, _loc: any) {
-      err_handler();
-    }
-  }
+	return {
+		sourceType: "module",
+		ecmaVersion: 6,
+		locations: true,
+		// tslint:disable-next-line:no-any
+		onInsertedSemicolon(end: any, loc: any) {
+			err_handler();
+		},
+		// tslint:disable-next-line:no-any
+		onTrailingComma(_end: any, _loc: any) {
+			err_handler();
+		},
+	};
 }
 
 function parseImport(code: string): es.Program | undefined {
-  let program: es.Program | undefined;
-  let has_errors = false;
-  try {
-    // we directly use acorn, because js-slang's parse is too restrictive
-    // with attributes and exports
-    program = (SyntacticParser.parse(code, createImportOptions(() => { has_errors = true; })) as unknown) as es.Program
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      has_errors = true;
-    } else {
-      throw error;
-    }
-  }
-  if (program && !has_errors) return program;
-  return undefined;
+	let program: es.Program | undefined;
+	let has_errors = false;
+	try {
+		// we directly use acorn, because js-slang's parse is too restrictive
+		// with attributes and exports
+		program = (SyntacticParser.parse(
+			code,
+			createImportOptions(() => {
+				has_errors = true;
+			})
+		) as unknown) as es.Program;
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			has_errors = true;
+		} else {
+			throw error;
+		}
+	}
+	if (program && !has_errors) return program;
+	return undefined;
 }
 
 export async function compile(
-  code: string,
-  context: Context
+	code: string,
+	context: Context
 ): Promise<WebAssembly.Module> {
-  //context.chapter = 3;
-  let estree: es.Program | undefined = slang_parse(code, context);
-  if (!estree) {
-    return Promise.reject(
-      new CompileError("js-slang cannot parse the program")
-    );
-  }
-  let es_str: string = JSON.stringify(estree);
-  let wasm_context: number = Sourceror.createContext((severity: number, location_file: string, location_start_line: number, location_start_column: number, location_end_line: number, location_end_column: number, message: string) => {
-    context.errors.push({
-      type: ErrorType.SYNTAX,
-      severity: severity >= 4 ? ErrorSeverity.ERROR : ErrorSeverity.WARNING, // Sourceror supports other severity levels, but js-slang does not
-      location: {
-        source: location_file ? location_file : undefined,
-        start: {
-          line: location_start_line,
-          column: location_start_column,
-        },
-        end: {
-          line: location_end_line,
-          column: location_end_column,
-        },
-      },
-      explain: (): string => message,
-      elaborate: (): string => "",
-    });
-  }, (name: string): Promise<string> => {
-    return cachedGetFile(name, name =>
-      fetch(name)
-        .then(rsp => rsp.text())
-        .then(rsptxt => {
-          if (rsptxt.split('\n', 1)[0] == "@SourceImports") {
-            // it is an import file, return it as is
-            return rsptxt;
-          }
-          else {
-            // it is a Source file, need to parse it with acorn
-            const estree: es.Program | undefined = parseImport(rsptxt);
-            if (!estree) {
-              return Promise.reject(
-                new CompileError("js-slang cannot parse the program")
-              );
-            }
-            return JSON.stringify(estree);
-          }
-        }));
-  });
-  return Sourceror.compile(wasm_context, es_str)
-    .then((wasm_binary: Uint8Array) => {
-      if (wasm_binary.byteLength > 0) {
-        return WebAssembly.compile(wasm_binary).catch((err: string) => {
-          context.errors.push({
-            type: ErrorType.SYNTAX,
-            severity: ErrorSeverity.ERROR,
-            location: {
-              source: undefined,
-              start: {
-                line: 0,
-                column: 0,
-              },
-              end: {
-                line: 0,
-                column: 0,
-              },
-            },
-            explain: (): string => err,
-            elaborate: (): string => "Your browser's WebAssembly engine is unable to compile the WebAssembly binary produced by Sourceror.  This is probably a bug in Sourceror; please report it.",
-          });
-          throw new CompileError("WebAssembly compilation error");
-        });
-      }
-      else {
-        throw new CompileError("Syntax error");
-      }
-    })
-    .finally(() => {
-      Sourceror.destroyContext(wasm_context);
-    });
+	//context.chapter = 3;
+	let estree: es.Program | undefined = slang_parse(code, context);
+	if (!estree) {
+		return Promise.reject(
+			new CompileError("js-slang cannot parse the program")
+		);
+	}
+	let es_str: string = JSON.stringify(estree);
+	let wasm_context: number = Sourceror.createContext(
+		(
+			severity: number,
+			location_file: string,
+			location_start_line: number,
+			location_start_column: number,
+			location_end_line: number,
+			location_end_column: number,
+			message: string
+		) => {
+			context.errors.push({
+				type: ErrorType.SYNTAX,
+				severity: severity >= 4 ? ErrorSeverity.ERROR : ErrorSeverity.WARNING, // Sourceror supports other severity levels, but js-slang does not
+				location: {
+					source: location_file ? location_file : undefined,
+					start: {
+						line: location_start_line,
+						column: location_start_column,
+					},
+					end: {
+						line: location_end_line,
+						column: location_end_column,
+					},
+				},
+				explain: (): string => message,
+				elaborate: (): string => "",
+			});
+		},
+		(name: string): Promise<string> => {
+			return cachedGetFile(name, (name) =>
+				fetch(name)
+					.then((rsp) => rsp.text())
+					.then((rsptxt) => {
+						if (rsptxt.split("\n", 1)[0] == "@SourceImports") {
+							// it is an import file, return it as is
+							return rsptxt;
+						} else {
+							// it is a Source file, need to parse it with acorn
+							const estree: es.Program | undefined = parseImport(rsptxt);
+							if (!estree) {
+								return Promise.reject(
+									new CompileError("js-slang cannot parse the program")
+								);
+							}
+							return JSON.stringify(estree);
+						}
+					})
+			);
+		}
+	);
+	return Sourceror.compile(wasm_context, es_str)
+		.then((wasm_binary: Uint8Array) => {
+			if (wasm_binary.byteLength > 0) {
+				return WebAssembly.compile(wasm_binary).catch((err: string) => {
+					context.errors.push({
+						type: ErrorType.SYNTAX,
+						severity: ErrorSeverity.ERROR,
+						location: {
+							source: undefined,
+							start: {
+								line: 0,
+								column: 0,
+							},
+							end: {
+								line: 0,
+								column: 0,
+							},
+						},
+						explain: (): string => err,
+						elaborate: (): string =>
+							"Your browser's WebAssembly engine is unable to compile the WebAssembly binary produced by Sourceror.  This is probably a bug in Sourceror; please report it.",
+					});
+					throw new CompileError("WebAssembly compilation error");
+				});
+			} else {
+				throw new CompileError("Syntax error");
+			}
+		})
+		.finally(() => {
+			Sourceror.destroyContext(wasm_context);
+		});
 }
 
 function read_js_result(linear_memory: WebAssembly.Memory): any {
-  const mem = new DataView(linear_memory.buffer);
-  const tag = mem.getUint32((1 << 20) - 12, true);
-  const data_offset = (1 << 20) - 8;
-  switch (tag) {
-    case 0:
-      return "(unassigned variable was returned)";
-    case 1:
-      return undefined;
-    case 2:
-      return mem.getFloat64(data_offset, true);
-    case 3:
-      return mem.getUint32(data_offset, true) !== 0;
-    case 4: {
-      const ptr = mem.getUint32(data_offset, true);
-      const len = mem.getUint32(ptr, true);
-      const decoder = new TextDecoder();
-      const res = decoder.decode(
-        new Uint8Array(linear_memory.buffer, ptr + 4, len)
-      );
-      return res;
-    }
-    case 5:
-      return "(function was returned)";
-    default:
-      return "(struct or invalid type (" + tag + ") was returned)";
-  }
+	const mem = new DataView(linear_memory.buffer);
+	const tag = mem.getUint32((1 << 20) - 12, true);
+	const data_offset = (1 << 20) - 8;
+	switch (tag) {
+		case 0:
+			return "(unassigned variable was returned)";
+		case 1:
+			return undefined;
+		case 2:
+			return mem.getFloat64(data_offset, true);
+		case 3:
+			return mem.getUint32(data_offset, true) !== 0;
+		case 4: {
+			const ptr = mem.getUint32(data_offset, true);
+			const len = mem.getUint32(ptr, true);
+			const decoder = new TextDecoder();
+			const res = decoder.decode(
+				new Uint8Array(linear_memory.buffer, ptr + 4, len)
+			);
+			return res;
+		}
+		case 5:
+			return "(function was returned)";
+		default:
+			return "(struct or invalid type (" + tag + ") was returned)";
+	}
 }
 
 function stringifySourcerorRuntimeErrorCode(code: number): [string, string] {
-  switch (code) {
-    case 0x0:
-      return ["General runtime error", ""];
-    case 0x1:
-      return [
-        "Out of memory",
-        "Strings and objects are allocated on the heap.  You have exhausted the available heap space.  Try recompiling your program with increased heap space.",
-      ];
-    case 0x10:
-      return ["General runtime type error", ""];
-    case 0x11:
-      return ["Function called with incorrect parameter type", ""];
-    case 0x12:
-      return ["Unary operator called with incorrect parameter type", ""];
-    case 0x13:
-      return ["Binary operator called with incorrect parameter type", ""];
-    case 0x16:
-      return ["Function call operator applied on a non-function", ""];
-    case 0x17:
-      return ["If statement has a non-boolean condition", ""];
-    case 0x1A:
-      return ["Variable used before initialization", ""];
-    default:
-      return [
-        "Unknown runtime error",
-        "This is probably a bug in Sourceror; please report it.",
-      ];
-  }
+	switch (code) {
+		case 0x0:
+			return ["General runtime error", ""];
+		case 0x1:
+			return [
+				"Out of memory",
+				"Strings and objects are allocated on the heap.  You have exhausted the available heap space.  Try recompiling your program with increased heap space.",
+			];
+		case 0x10:
+			return ["General runtime type error", ""];
+		case 0x11:
+			return ["Function called with incorrect parameter type", ""];
+		case 0x12:
+			return ["Unary operator called with incorrect parameter type", ""];
+		case 0x13:
+			return ["Binary operator called with incorrect parameter type", ""];
+		case 0x16:
+			return ["Function call operator applied on a non-function", ""];
+		case 0x17:
+			return ["If statement has a non-boolean condition", ""];
+		case 0x1a:
+			return ["Variable used before initialization", ""];
+		default:
+			return [
+				"Unknown runtime error",
+				"This is probably a bug in Sourceror; please report it.",
+			];
+	}
 }
 
 // Just a unique identifier used for throwing exceptions while running the webassembly code
 const propagationToken = {};
 
 export async function run(
-  wasm_module: WebAssembly.Module,
-  platform: any,
-  transcoder: Transcoder,
-  context: Context,
+	wasm_module: WebAssembly.Module,
+	platform: any,
+	transcoder: Transcoder,
+	context: Context
 ): Promise<any> {
-  const real_imports = Object.assign({}, platform);
+	const real_imports = Object.assign({}, platform);
 
-  tailCall().then((tailCallSupported) => {
-    if (tailCallSupported) {
-      // TODONIG: initialize something like wasm_module.optimize_tail_calls()??
-      console.info("Tail call supported")
-    } else {
-      console.info("Tail call not supported")
-    }
-  }).catch(err => {
-    throw new RuntimeError(err);
-  })
+	tailCall()
+		.then((tailCallSupported) => {
+			if (tailCallSupported) {
+				// TODONIG: initialize something like wasm_module.optimize_tail_calls()??
+				console.info("Tail call supported");
+			} else {
+				console.info("Tail call not supported");
+			}
+		})
+		.catch((err) => {
+			throw new RuntimeError(err);
+		});
 
-  real_imports.core = {
-    error: (
-      code: number,
-      detail: number,
-      file: number,
-      start_line: number,
-      start_column: number,
-      end_line: number,
-      end_column: number,
-    ) => {
-      const [explain, elaborate] = stringifySourcerorRuntimeErrorCode(code);
-      context.errors.push({
-        type: ErrorType.RUNTIME,
-        severity: ErrorSeverity.ERROR,
-        location: {
-          source: undefined,
-          start: {
-            line: start_line,
-            column: start_column,
-          },
-          end: {
-            line: end_line,
-            column: end_column,
-          },
-        },
-        explain: (): string => explain,
-        elaborate: (): string => elaborate,
-      });
-      throw propagationToken; // to stop the webassembly binary immediately
-    },
-    abort: () => {
-      context.errors.push({
-        type: ErrorType.RUNTIME,
-        severity: ErrorSeverity.ERROR,
-        location: {
-          source: null,
-          start: {
-            line: 0,
-            column: 0,
-          },
-          end: {
-            line: 0,
-            column: 0,
-          },
-        },
-        explain: (): string => "Execution aborted by call to error()",
-        elaborate: (): string => "",
-      });
-      throw propagationToken; // to stop the webassembly binary immediately
-    },
-  };
-  return WebAssembly.instantiate(wasm_module, real_imports).then((instance) => {
-    transcoder.setMem(new DataView((instance.exports.linear_memory as WebAssembly.Memory).buffer));
-    transcoder.setAllocateStringFunc(instance.exports.allocate_string as (len: number) => number);
-    try {
-      (instance.exports.main as Function)();
-      return read_js_result(
-        instance.exports.linear_memory as WebAssembly.Memory
-      );
-    } catch (e) {
-      if (e === propagationToken) {
-        throw new RuntimeError("runtime error");
-      } else {
-        context.errors.push({
-          type: ErrorType.RUNTIME,
-          severity: ErrorSeverity.ERROR,
-          location: {
-            source: null,
-            start: {
-              line: 0,
-              column: 0,
-            },
-            end: {
-              line: 0,
-              column: 0,
-            },
-          },
-          explain: (): string => e.toString(),
-          elaborate: (): string => e.toString(),
-        });
-        throw e;
-      }
-    }
-  }, (err: string) => {
-    context.errors.push({
-      type: ErrorType.SYNTAX,
-      severity: ErrorSeverity.ERROR,
-      location: {
-        source: null,
-        start: {
-          line: 0,
-          column: 0,
-        },
-        end: {
-          line: 0,
-          column: 0,
-        },
-      },
-      explain: (): string => err,
-      elaborate: (): string => "Your browser's WebAssembly engine is unable to instantiate the WebAssembly module.",
-    });
-      throw new CompileError("WebAssembly instantiation error");
-  });
+	real_imports.core = {
+		error: (
+			code: number,
+			detail: number,
+			file: number,
+			start_line: number,
+			start_column: number,
+			end_line: number,
+			end_column: number
+		) => {
+			const [explain, elaborate] = stringifySourcerorRuntimeErrorCode(code);
+			context.errors.push({
+				type: ErrorType.RUNTIME,
+				severity: ErrorSeverity.ERROR,
+				location: {
+					source: undefined,
+					start: {
+						line: start_line,
+						column: start_column,
+					},
+					end: {
+						line: end_line,
+						column: end_column,
+					},
+				},
+				explain: (): string => explain,
+				elaborate: (): string => elaborate,
+			});
+			throw propagationToken; // to stop the webassembly binary immediately
+		},
+		abort: () => {
+			context.errors.push({
+				type: ErrorType.RUNTIME,
+				severity: ErrorSeverity.ERROR,
+				location: {
+					source: null,
+					start: {
+						line: 0,
+						column: 0,
+					},
+					end: {
+						line: 0,
+						column: 0,
+					},
+				},
+				explain: (): string => "Execution aborted by call to error()",
+				elaborate: (): string => "",
+			});
+			throw propagationToken; // to stop the webassembly binary immediately
+		},
+	};
+	return WebAssembly.instantiate(wasm_module, real_imports).then(
+		(instance) => {
+			transcoder.setMem(
+				new DataView(
+					(instance.exports.linear_memory as WebAssembly.Memory).buffer
+				)
+			);
+			transcoder.setAllocateStringFunc(
+				instance.exports.allocate_string as (len: number) => number
+			);
+			try {
+				(instance.exports.main as Function)();
+				return read_js_result(
+					instance.exports.linear_memory as WebAssembly.Memory
+				);
+			} catch (e) {
+				if (e === propagationToken) {
+					throw new RuntimeError("runtime error");
+				} else {
+					context.errors.push({
+						type: ErrorType.RUNTIME,
+						severity: ErrorSeverity.ERROR,
+						location: {
+							source: null,
+							start: {
+								line: 0,
+								column: 0,
+							},
+							end: {
+								line: 0,
+								column: 0,
+							},
+						},
+						explain: (): string => e.toString(),
+						elaborate: (): string => e.toString(),
+					});
+					throw e;
+				}
+			}
+		},
+		(err: string) => {
+			context.errors.push({
+				type: ErrorType.SYNTAX,
+				severity: ErrorSeverity.ERROR,
+				location: {
+					source: null,
+					start: {
+						line: 0,
+						column: 0,
+					},
+					end: {
+						line: 0,
+						column: 0,
+					},
+				},
+				explain: (): string => err,
+				elaborate: (): string =>
+					"Your browser's WebAssembly engine is unable to instantiate the WebAssembly module.",
+			});
+			throw new CompileError("WebAssembly instantiation error");
+		}
+	);
 }

--- a/sourceror-driver/src/index.ts
+++ b/sourceror-driver/src/index.ts
@@ -8,6 +8,7 @@ export { makePlatformImports } from "./platform";
 import { Transcoder } from "./transcoder";
 export { Transcoder };
 import { cachedGetFile } from "./cache";
+import { tailCall } from "wasm-feature-detect";
 
 export class CompileError extends Error {
   constructor(message: string) {
@@ -216,6 +217,18 @@ export async function run(
   context: Context,
 ): Promise<any> {
   const real_imports = Object.assign({}, platform);
+
+  tailCall().then((tailCallSupported) => {
+    if (tailCallSupported) {
+      // TODONIG: initialize something like wasm_module.optimize_tail_calls()??
+      console.info("Tail call supported")
+    } else {
+      console.info("Tail call not supported")
+    }
+  }).catch(err => {
+    throw new RuntimeError(err);
+  })
+
   real_imports.core = {
     error: (
       code: number,

--- a/sourceror-driver/src/index.ts
+++ b/sourceror-driver/src/index.ts
@@ -134,7 +134,11 @@ export async function compile(
 			);
 		}
 	);
-	return Sourceror.compile(wasm_context, es_str)
+
+	let isTailCallSupported = await tailCall();
+	console.info("WASM Tail Calls supported: ", isTailCallSupported);
+
+	return Sourceror.compile(wasm_context, es_str, isTailCallSupported)
 		.then((wasm_binary: Uint8Array) => {
 			if (wasm_binary.byteLength > 0) {
 				return WebAssembly.compile(wasm_binary).catch((err: string) => {
@@ -237,19 +241,6 @@ export async function run(
 	context: Context
 ): Promise<any> {
 	const real_imports = Object.assign({}, platform);
-
-	tailCall()
-		.then((tailCallSupported) => {
-			if (tailCallSupported) {
-				// TODONIG: initialize something like wasm_module.optimize_tail_calls()??
-				console.info("Tail call supported");
-			} else {
-				console.info("Tail call not supported");
-			}
-		})
-		.catch((err) => {
-			throw new RuntimeError(err);
-		});
 
 	real_imports.core = {
 		error: (

--- a/sourceror-driver/src/wrapper.ts
+++ b/sourceror-driver/src/wrapper.ts
@@ -16,8 +16,8 @@ export function destroyContext(context: Context) {
   delete contexts[context];
 }
 
-export function compile(context: Context, code: string) {
-  return LoadWasm().then(module => module.compile(context, code));
+export function compile(context: Context, code: string, enableTailCalls: boolean) {
+  return LoadWasm().then(module => module.compile(context, code, enableTailCalls));
 }
 
 function compilerLog(context: Context, severity: number, location_file: string, location_start_line: number, location_start_column: number, location_end_line: number, location_end_column: number, message: string) {

--- a/sourceror-driver/src/wrapper.ts
+++ b/sourceror-driver/src/wrapper.ts
@@ -3,6 +3,11 @@ import LoadWasm from './load-wasm';
 export type Context = number;
 export type LogCallback = (severity: number, location_file: string, location_start_line: number, location_start_column: number, location_end_line: number, location_end_column: number, message: string) => void;
 export type FetchCallback = (name: string) => Promise<string>;
+export type CompilationFlags = {
+  tailCall: boolean,
+  multiValue: boolean,
+  bulkMemory: boolean
+}
 
 const contexts: Array<[LogCallback, FetchCallback]> = [];
 
@@ -16,8 +21,8 @@ export function destroyContext(context: Context) {
   delete contexts[context];
 }
 
-export function compile(context: Context, code: string, enableTailCalls: boolean) {
-  return LoadWasm().then(module => module.compile(context, code, enableTailCalls));
+export function compile(context: Context, code: string, compilationFlags: CompilationFlags) {
+  return LoadWasm().then(module => module.compile(context, code, compilationFlags.multiValue, compilationFlags.bulkMemory, compilationFlags.tailCall));
 }
 
 function compilerLog(context: Context, severity: number, location_file: string, location_start_line: number, location_start_column: number, location_end_line: number, location_end_column: number, message: string) {

--- a/sourceror-driver/yarn.lock
+++ b/sourceror-driver/yarn.lock
@@ -1128,6 +1128,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+wasm-feature-detect@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/wasm-feature-detect/-/wasm-feature-detect-1.2.9.tgz#857e5ddc16a476c50be0bff7cd4ac875d60041c1"
+  integrity sha512-2E9/gtLVLpv2wnZDyYv8WY2dR9gHbmyv5uhZsnOcMSzqc78aGZpKQORPNcnrPwAU23nFUo7GAwKuoTAWRgsJ7Q==
+
 wasm-pack@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/wasm-pack/-/wasm-pack-0.9.1.tgz#f1e80814c7197a469e700ff15b6c16cad5dbb2ae"


### PR DESCRIPTION
Fixes #5 

# Support for Tail Calls

This PR introduces support for tail calls, where supported by browsers.

We rely on [wasm-feature-detect](https://github.com/GoogleChromeLabs/wasm-feature-detect) in order to determine which features are supported by respective browsers. (We are only using `tailCall()` for now)

## Browser Support

As of now, tail calls are not supported by any browser. Refer to the [WASM Road Map](https://webassembly.org/roadmap/) for browser support. 

![image](https://user-images.githubusercontent.com/35065597/110323283-5dd5da80-804f-11eb-99b2-885c0e5bd7fc.png)
